### PR TITLE
asaf.use_new_resolver

### DIFF
--- a/src/piprules/pipcompat.py
+++ b/src/piprules/pipcompat.py
@@ -12,7 +12,7 @@ from pip._internal.operations.prepare import make_distribution_for_install_requi
 from pip._internal.req import parse_requirements, InstallRequirement
 from pip._internal.req.constructors import install_req_from_req_string, install_req_from_parsed_requirement
 from pip._internal.req.req_tracker import get_requirement_tracker
-from pip._internal.resolution.legacy.resolver import Resolver
+from pip._internal.resolution.resolvelib.resolver import Resolver
 from pip._internal.wheel_builder import build, should_build_for_wheel_command
 from pip._internal.models.wheel import Wheel
 from pip._internal.cache import WheelCache

--- a/src/piprules/requirements.py
+++ b/src/piprules/requirements.py
@@ -81,7 +81,7 @@ class Collection(object):
 
     def condense(self):
         LOG.debug("Condensing requirement collection into a set")
-        return [requirement for requirement in self._generate_condensed_requirements()]
+        return {requirement.name: requirement for requirement in self._generate_condensed_requirements()}
 
     def _generate_condensed_requirements(self):
         for name, group in self._iterate_grouped_requirements():


### PR DESCRIPTION
This branch switches the lock tool to using the new resolver that is now the default as of pip 20.3. The current version of the resolver will happily allow you to upgrade library A that depends on library B without checking that library B is at a compatible version with the upgraded version of A. See their blogpost for further details - https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020.